### PR TITLE
Store selected source in URL fragment, recall on page load

### DIFF
--- a/views/tally.pug
+++ b/views/tally.pug
@@ -20,7 +20,7 @@ html
     script(src="https://code.jquery.com/jquery-3.4.1.min.js")
     script.
         var lastUpdate = {};
-        var camSelection = "ALL";
+        var camSelection = window.location.hash.split('#')[1] || "ALL";
         var programColor = "#FF0000";
         var previewColor = "#00FF00";
 
@@ -91,6 +91,7 @@ html
         }
         function setCamera() {
             camSelection = $('#cameraSelection').val();
+            window.location.hash = camSelection
             updateTally();
         }
         $('#cameraSelection').change(() => {setCamera();})


### PR DESCRIPTION
This modifies the JS on the tally display page to store the selected source/camera in the URL fragment upon selection. This makes the tally display for an individual camera directly addressable and bookmarkable.

Upon page load, it then reads the selected camera out of the URL fragment (if present); otherwise behavior is unchanged.

Resolves #10.